### PR TITLE
Delete on ack

### DIFF
--- a/ack_queue.go
+++ b/ack_queue.go
@@ -49,9 +49,9 @@ const (
     `
 )
 
-var ackAck = map[bool]string{
-	false: ackAckQuery,
-	true:  ackAckDelete,
+var ackAckActs = map[AckAction]string{
+	AckMark:   ackAckQuery,
+	AckDelete: ackAckDelete,
 }
 
 // NewAckQueue creates a new ack queue.
@@ -67,7 +67,7 @@ func NewAckQueue(filePath string, opts AckOpts) (*AcknowledgeableQueue, error) {
 	formattedCreateTableQuery := fmt.Sprintf(ackCreateTableQuery, tableName)
 	formattedEnqueueQuery := fmt.Sprintf(ackEnqueueQuery, tableName)
 	formattedTryDequeueQuery := fmt.Sprintf(ackTryDequeueQuery, tableName)
-	formattedAckQuery := fmt.Sprintf(ackAck[opts.DeleteUponAck], tableName)
+	formattedAckQuery := fmt.Sprintf(ackAckActs[opts.AckAction], tableName)
 	formattedLenQuery := fmt.Sprintf(ackLenQuery, tableName)
 
 	err = internal.PrepareDB(db, formattedCreateTableQuery, formattedEnqueueQuery, formattedTryDequeueQuery, formattedAckQuery, formattedLenQuery)

--- a/ackopts.go
+++ b/ackopts.go
@@ -5,22 +5,30 @@ import "time"
 // AckOpts represents the queue-level settings for how acknowledgement
 // of messages is handled.
 const (
-	InfiniteRetries = -1
+	InfiniteRetries           = -1
+	AckMark         AckAction = iota
+	AckDelete
 )
 
-type AckOpts struct {
-	AckTimeout   time.Duration
-	MaxRetries   int
-	RetryBackoff time.Duration
+type (
+	AckAction int
 
-	// DeleteUponAck detes record from the queue when acked, thus lowering
-	// maintenance costs (database does not grow).
-	DeleteUponAck bool
+	AckOpts struct {
+		AckTimeout   time.Duration
+		MaxRetries   int
+		RetryBackoff time.Duration
 
-	// Has a default behaviour of dropping the message
-	BehaviourOnFailure func(msg Msg) error
-	FailureCallbacks   []func(msg Msg) error
-}
+		// AckAction determines the fate of the related database record when the
+		// message is acknowledged.
+		// - AckMark (default behaivour) marks the record as done
+		// - AckDelete deletes the record.
+		AckAction AckAction
+
+		// Has a default behaviour of dropping the message
+		BehaviourOnFailure func(msg Msg) error
+		FailureCallbacks   []func(msg Msg) error
+	}
+)
 
 // RegisterOnFailureCallback adds a callback to the queue that is called when
 // a message fails to acknowledge.

--- a/ackopts.go
+++ b/ackopts.go
@@ -13,6 +13,10 @@ type AckOpts struct {
 	MaxRetries   int
 	RetryBackoff time.Duration
 
+	// DeleteUponAck detes record from the queue when acked, thus lowering
+	// maintenance costs (database does not grow).
+	DeleteUponAck bool
+
 	// Has a default behaviour of dropping the message
 	BehaviourOnFailure func(msg Msg) error
 	FailureCallbacks   []func(msg Msg) error


### PR DESCRIPTION
Such a queue is needed in a production, to be of low maintenance. So when the message is delivered there's now an option to have the message deleted from the database instead of recording the delivery. This sacrifices the trace (there are logs though) but keeps the size of the database down to active messages and perhaps some errors.

A new `AckOpts` element is added, `AckAction`, with two possible values:

- `AckMark` (default) marks the record in the database
- `AckDelete` deletes the record from the database