### PR TITLE
Ext db

### DIFF
--- a/# External database.md
+++ b/# External database.md
@@ -1,0 +1,111 @@
+# External database
+
+## Database API
+
+Gopq allows user to provide own external database. This can assist with the
+database maintenance and opens the queue to other uses (and abuses).
+
+Two types of queue are supported: `Queue` and `AcknowledgeableQueue`. The latter
+is not only a functional extension but also uses extended calls (additional
+parameters) to the basic operations, so there are essentially two different APIs.
+
+### Store procedure names
+
+While the signature of these procedures is fixed, names can differ. The names
+from the table above are recognised out of the box, however calling something
+like
+
+```go
+q := gopq.func NewExternalQueueWithQueries(db,
+    gopq.BaseQueries {
+        enqueue:    "call InsertIntoQueue(?)",
+        tryDequeue: "call GetTopElement()",
+        len:        "call GetQueueLength()",
+    })
+```
+
+would work with procedures of different names. Name of the underlying table is
+not required for queue operation.
+
+### Store or delete processed elements
+
+When the external_queue is initialized, it defaults to keep the processed record
+(just mark it as such). This requires additional maintenance with long running
+setups, so it is possible to request to remove the processed records from the
+table. Thus API provides for two distinct "pop" procedures. This is mostly to
+maintain compatibility with internal Sqlite implementation. The decision which
+one to use is made at the queue initialization. If you only use one (or another),
+you can pass the same procedure implementation afor both; and if you provide
+your own names, you can at any rate provide only a single "pop" procedure name.
+
+The following queues will behave the same:
+
+```go
+q1 := gopq.func NewExternalQueue(db, DeleteOnDequeue())
+q2 := gopq.func NewExternalQueueWithQueries(db,
+    gopq.BaseQueries {
+        enqueue:    "call gopq_push(?)",
+        tryDequeue: "call gopq_pop_delete()",
+        len:        "call gopq_len()",
+    })
+```
+
+and, providing the following stored procedure:
+
+```sql
+create procedure gopq_pop_store()
+begin
+    call gopq_pop_delete();
+end
+```
+
+there's also the third option:
+
+```go
+q3 := gopq.func NewExternalQueue(db)
+```
+
+The queue `q1` selected behaivour upon initialization - it calls
+`gopq_pop_delete`. The queue `q2` also selected behaivour upon initialization -
+it provided `gopq_pop_delete` as the "pop" procedure. The final, `q3`, should be
+avoided wherever possible because the name (promise) and behaivour of the stored
+procedure differ. However at the end of the day, `q3` uses `gopq_pop_store`
+(default) and this behind the scene deletes the processed element.
+
+With **unique** queues, you have to select between two definitions of uniqueness:
+
+- at most one copy of a given element is active at the time
+- a given copy accurs at most once in the queue for the lifespan of the queue
+
+For the second interpretation, one must not delete elements when processed.
+
+### API: Queue
+
+The external database must satisfy the following stored procedures:
+
+| Function                | SQL header                 | result set                | records |
+|-------------------------|----------------------------|---------------------------|:-------:|
+| enqueue                 | `gopq_push(it blob(1024))` |                           |    0    |
+| dequeue (store record)  | `gopq_pop_store()`         | `id int, item blob(1024)` | 0 or 1  |
+| dequeue (delete record) | `gopq_pop_delete()`        | `id int, item blob(1024)` | 0 or 1  |
+| length                  | `gopq_len()`               | `int`                     |    1    |
+
+Obviously the behaivour of the queue depends heavily on the implementation of
+these SQL procedures.
+
+### API: AcknoweledgabeQueue
+
+The external database must satisfy the following stored procedures:
+
+| Function            | SQL header                                     | result set                                | records |
+|---------------------|------------------------------------------------|-------------------------------------------|:-------:|
+| enqueue             | `gopq_push_ack(it blob(1024))`                 |                                           |    0    |
+| dequeue             | `gopq_pop_ack(int now, int deadline)`          | `id as int, item as blob(1024)`           | 0 or 1  |
+| ack (store record)  | `gopq_ack_store(int id, int now)`              |                                           |    0    |
+| ack (delete record) | `gopq_ack_delete(int id, int now)`             |                                           |    0    |
+| length              | `gopq_len(now int)`                            | `int`                                     |    1    |
+| details             | `gopq_selectItemDetails(id int)`               | `retry_count as int, ack_deadline as int` | 0 or 1  |
+| delete              | `gopq_deleteItem(id int)`                      | `item as blob(1024)`                      |    1    |
+| forRetry            | `gopq_updateForRetry(deadline int, id int)`    |                                           |    0    |
+| expire              | `gopq_expireAckDeadline(deadline int, id int)` |                                           |    0    |
+

--- a/ack_queue.go
+++ b/ack_queue.go
@@ -82,14 +82,20 @@ func NewAckQueue(filePath string, opts AckOpts) (*AcknowledgeableQueue, error) {
 			pollInterval: defaultPollInterval,
 			notifyChan:   internal.MakeNotifyChan(),
 			queries: baseQueries{
-				enqueue:     formattedEnqueueQuery,
-				tryDequeue:  formattedTryDequeueQuery,
-				len:         formattedLenQuery,
+				enqueue:    formattedEnqueueQuery,
+				tryDequeue: formattedTryDequeueQuery,
+				len:        formattedLenQuery,
 			},
 		},
 		AckOpts: opts,
 		ackQueries: ackQueries{
 			ack: formattedAckQuery,
+			ackUtilsQueries: ackUtilsQueries{
+				details:  fmt.Sprintf(sqlite.details, tableName),
+				delete:   fmt.Sprintf(sqlite.delete, tableName),
+				forRetry: fmt.Sprintf(sqlite.forRetry, tableName),
+				expire:   fmt.Sprintf(sqlite.expire, tableName),
+			},
 		},
 	}, nil
 }

--- a/ack_queue.go
+++ b/ack_queue.go
@@ -82,7 +82,6 @@ func NewAckQueue(filePath string, opts AckOpts) (*AcknowledgeableQueue, error) {
 			pollInterval: defaultPollInterval,
 			notifyChan:   internal.MakeNotifyChan(),
 			queries: baseQueries{
-				createTable: formattedCreateTableQuery,
 				enqueue:     formattedEnqueueQuery,
 				tryDequeue:  formattedTryDequeueQuery,
 				len:         formattedLenQuery,

--- a/ack_queue.go
+++ b/ack_queue.go
@@ -78,7 +78,6 @@ func NewAckQueue(filePath string, opts AckOpts) (*AcknowledgeableQueue, error) {
 	return &AcknowledgeableQueue{
 		Queue: Queue{
 			db:           db,
-			name:         tableName,
 			pollInterval: defaultPollInterval,
 			notifyChan:   internal.MakeNotifyChan(),
 			queries: baseQueries{

--- a/ack_queue.go
+++ b/ack_queue.go
@@ -49,9 +49,9 @@ const (
     `
 )
 
-var ackAck = map[bool]string{
-	false: ackAckQuery,
-	true:  ackAckDelete,
+var ackAckActs = map[AckAction]string{
+	AckMark:   ackAckQuery,
+	AckDelete: ackAckDelete,
 }
 
 // NewAckQueue creates a new ack queue.
@@ -67,7 +67,7 @@ func NewAckQueue(filePath string, opts AckOpts) (*AcknowledgeableQueue, error) {
 	formattedCreateTableQuery := fmt.Sprintf(ackCreateTableQuery, tableName)
 	formattedEnqueueQuery := fmt.Sprintf(ackEnqueueQuery, tableName)
 	formattedTryDequeueQuery := fmt.Sprintf(ackTryDequeueQuery, tableName)
-	formattedAckQuery := fmt.Sprintf(ackAck[opts.DeleteUponAck], tableName)
+	formattedAckQuery := fmt.Sprintf(ackAckActs[opts.AckAction], tableName)
 	formattedLenQuery := fmt.Sprintf(ackLenQuery, tableName)
 
 	err = internal.PrepareDB(db, formattedCreateTableQuery, formattedEnqueueQuery, formattedTryDequeueQuery, formattedAckQuery, formattedLenQuery)

--- a/ackopts.go
+++ b/ackopts.go
@@ -5,22 +5,30 @@ import "time"
 // AckOpts represents the queue-level settings for how acknowledgement
 // of messages is handled.
 const (
-	InfiniteRetries = -1
+	InfiniteRetries           = -1
+	AckMark         AckAction = iota
+	AckDelete
 )
 
-type AckOpts struct {
-	AckTimeout   time.Duration
-	MaxRetries   int
-	RetryBackoff time.Duration
+type (
+	AckAction int
 
-	// DeleteUponAck detes record from the queue when acked, thus lowering
-	// maintenance costs (database does not grow).
-	DeleteUponAck bool
+	AckOpts struct {
+		AckTimeout   time.Duration
+		MaxRetries   int
+		RetryBackoff time.Duration
 
-	// Has a default behaviour of dropping the message
-	BehaviourOnFailure func(msg Msg) error
-	FailureCallbacks   []func(msg Msg) error
-}
+		// AckAction determines the fate of the related database record when the
+		// message is acknowledged.
+		// - AckMark (default behaivour) marks the record as done
+		// - AckDelete deletes the record.
+		AckAction AckAction
+
+		// Has a default behaviour of dropping the message
+		BehaviourOnFailure func(msg Msg) error
+		FailureCallbacks   []func(msg Msg) error
+	}
+)
 
 // RegisterOnFailureCallback adds a callback to the queue that is called when
 // a message fails to acknowledge.

--- a/ackopts.go
+++ b/ackopts.go
@@ -13,6 +13,10 @@ type AckOpts struct {
 	MaxRetries   int
 	RetryBackoff time.Duration
 
+	// DeleteUponAck detes record from the queue when acked, thus lowering
+	// maintenance costs (database does not grow).
+	DeleteUponAck bool
+
 	// Has a default behaviour of dropping the message
 	BehaviourOnFailure func(msg Msg) error
 	FailureCallbacks   []func(msg Msg) error

--- a/external_ack_queue.go
+++ b/external_ack_queue.go
@@ -1,0 +1,55 @@
+package gopq
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/mattdeak/gopq/internal"
+)
+
+// NewExternalQueue creates a new queue based on external database. The
+// behaivour of the queue is based on database implementation details.
+func NewExternalAckQueue(db *sql.DB, ackOpts AckOpts, opts ...QueueOptions) (*AcknowledgeableQueue, error) {
+	qo := Opts{}
+	qo.Apply(opts...)
+
+	ack := map[DequeueAction]string{
+		DequeueMark:   "call gopq_ack_store(?, ?)",
+		DequeueDelete: "call gopq_ack_delete(?, ?)",
+	}
+	bq := baseQueries{
+		enqueue:    "call gopq_push_ack(?)",
+		tryDequeue: "call gopq_pop_ack(?, ?)",
+		len:        "call gopq_len_ack(?)",
+	}
+	aq := ackQueries{
+		ackUtilsQueries: ackUtilsQueries{
+			details:  "call gopq_selectItemDetails(?)",
+			delete:   "call gopq_deleteItem(?)",
+			forRetry: "call gopq_updateForRetry(?, ?)",
+			expire:   "call gopq_expireAckDeadline(?, ?)",
+		},
+		ack: ack[qo.DequeueAction],
+	}
+	return NewExternalAckQueueWithQueries(db, bq, aq, ackOpts, opts...)
+}
+
+// NewExternalQueue creates a new queue based on external database. The
+// behaivour of the queue is based on database implementation details.
+func NewExternalAckQueueWithQueries(db *sql.DB, bq baseQueries, aq ackQueries, ackOpts AckOpts, opts ...QueueOptions) (*AcknowledgeableQueue, error) {
+	err := internal.PrepareDB(db, "", bq.enqueue, bq.tryDequeue, bq.len, aq.ack, aq.delete, aq.details, aq.forRetry, aq.expire)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create external queue: %w", err)
+	}
+
+	return &AcknowledgeableQueue{
+		Queue: Queue{
+			db:           db,
+			pollInterval: defaultPollInterval,
+			notifyChan:   internal.MakeNotifyChan(),
+			queries:      bq,
+		},
+		AckOpts:    ackOpts,
+		ackQueries: aq,
+	}, nil
+}

--- a/external_queue.go
+++ b/external_queue.go
@@ -22,12 +22,12 @@ func NewExternalQueue(db *sql.DB, opts ...QueueOptions) (*Queue, error) {
 		tryDequeue: dequeue[qo.DequeueAction],
 		len:        "call gopq_len()",
 	}
-	return NewExternalQueueWithQueries(db, q)
+	return NewExternalQueueWithQueries(db, q, opts...)
 }
 
 // NewExternalQueue creates a new queue based on external database. The
 // behaivour of the queue is based on database implementation details.
-func NewExternalQueueWithQueries(db *sql.DB, q baseQueries) (*Queue, error) {
+func NewExternalQueueWithQueries(db *sql.DB, q baseQueries, opts ...QueueOptions) (*Queue, error) {
 	err := internal.PrepareDB(db, "", q.enqueue, q.tryDequeue, q.len)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create external queue: %w", err)

--- a/external_queue.go
+++ b/external_queue.go
@@ -1,0 +1,43 @@
+package gopq
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/mattdeak/gopq/internal"
+)
+
+// NewExternalQueue creates a new queue based on external database. The
+// behaivour of the queue is based on database implementation details.
+func NewExternalQueue(db *sql.DB, opts ...QueueOptions) (*Queue, error) {
+	qo := Opts{}
+	qo.Apply(opts...)
+
+	dequeue := map[DequeueAction]string{
+		DequeueMark:   "call gopq_pop_store()",
+		DequeueDelete: "call gopq_pop_delete()",
+	}
+	q := baseQueries{
+		enqueue:    "call gopq_push(?)",
+		tryDequeue: dequeue[qo.DequeueAction],
+		len:        "call gopq_len()",
+	}
+	return NewExternalQueueWithQueries(db, q)
+}
+
+// NewExternalQueue creates a new queue based on external database. The
+// behaivour of the queue is based on database implementation details.
+func NewExternalQueueWithQueries(db *sql.DB, q baseQueries) (*Queue, error) {
+	err := internal.PrepareDB(db, "", q.enqueue, q.tryDequeue, q.len)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create external queue: %w", err)
+	}
+
+	return &Queue{
+		db:           db,
+		pollInterval: defaultPollInterval,
+		notifyChan:   internal.MakeNotifyChan(),
+		queries:      q,
+	}, nil
+
+}

--- a/internal/initialize_db.go
+++ b/internal/initialize_db.go
@@ -27,9 +27,11 @@ func InitializeDB(fileName string) (*sql.DB, error) {
 }
 
 func PrepareDB(db *sql.DB, createTableQuery string, queries ...string) error {
-	_, err := db.Exec(createTableQuery)
-	if err != nil {
-		return fmt.Errorf("failed to create table: %w", err)
+	if len(createTableQuery) > 0 {
+		_, err := db.Exec(createTableQuery)
+		if err != nil {
+			return fmt.Errorf("failed to create table: %w", err)
+		}
 	}
 
 	for _, query := range queries {

--- a/opts.go
+++ b/opts.go
@@ -1,0 +1,44 @@
+package gopq
+
+// Opts represents the queue-level settings for how dequeue is handled.
+const (
+	DequeueMark DequeueAction = iota
+	DequeueDelete
+)
+
+type (
+	DequeueAction int
+
+	Opts struct {
+		// DequeueAction determines the fate of the related database record when
+		// the message is dequeued.
+		// - DequeueMark (default behaivour) marks the record as done
+		// - DequeueDelete deletes the record.
+		DequeueAction DequeueAction
+	}
+
+	QueueOptions func(*Opts) error
+)
+
+func (co *Opts) Apply(opts ...QueueOptions) error {
+	for _, op := range opts {
+		if err := op(co); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func DeleteOnDeququq(o *Opts) QueueOptions {
+	return func(o *Opts) error {
+		o.DequeueAction = DequeueDelete
+		return nil
+	}
+}
+
+func MarkOnDeququq(o *Opts) QueueOptions {
+	return func(o *Opts) error {
+		o.DequeueAction = DequeueMark
+		return nil
+	}
+}

--- a/queue.go
+++ b/queue.go
@@ -82,7 +82,6 @@ type Msg struct {
 // It contains the database connection, queue name, and other necessary fields for queue operations.
 type Queue struct {
 	db           *sql.DB
-	name         string
 	pollInterval time.Duration
 	notifyChan   chan struct{}
 	queries      baseQueries

--- a/queue.go
+++ b/queue.go
@@ -95,12 +95,20 @@ type AcknowledgeableQueue struct {
 }
 
 type baseQueries struct {
-	enqueue     string
-	tryDequeue  string
-	len         string
+	enqueue    string
+	tryDequeue string
+	len        string
+}
+
+type ackUtilsQueries struct {
+	details  string
+	delete   string
+	forRetry string
+	expire   string
 }
 
 type ackQueries struct {
+	ackUtilsQueries
 	ack string
 }
 
@@ -224,14 +232,14 @@ func (q *AcknowledgeableQueue) AckCtx(ctx context.Context, id int64) error {
 // It takes the ID of the message to negative acknowledge.
 // This is non-blocking, and will return immediately.
 func (q *AcknowledgeableQueue) TryNack(id int64) error {
-	return nackImpl(context.Background(), q.db, q.name, id, q.AckOpts)
+	return q.ackQueries.nackImpl(context.Background(), q.db, id, q.AckOpts)
 }
 
 // TryNackCtx indicates that an item processing has failed and should be requeued.
 // It takes the ID of the message to negative acknowledge.
 // This is non-blocking, and will return immediately.
 func (q *AcknowledgeableQueue) TryNackCtx(ctx context.Context, id int64) error {
-	return nackImpl(ctx, q.db, q.name, id, q.AckOpts)
+	return q.ackQueries.nackImpl(ctx, q.db, id, q.AckOpts)
 }
 
 // Nack indicates that an item processing has failed and should be requeued.
@@ -285,7 +293,7 @@ func (q *AcknowledgeableQueue) TryDequeueCtx(ctx context.Context) (Msg, error) {
 // It takes the ID of the message to expire the acknowledgement deadline for.
 // Returns an error if the operation fails or the message doesn't exist.
 func (q *AcknowledgeableQueue) ExpireAck(id int64) error {
-	return expireAckDeadline(q.db, q.name, id)
+	return q.ackQueries.expireAckDeadline(q.db, id)
 }
 
 // SetBehaviourOnFailure sets the behaviour on failure for the queue.

--- a/queue.go
+++ b/queue.go
@@ -95,7 +95,6 @@ type AcknowledgeableQueue struct {
 }
 
 type baseQueries struct {
-	createTable string
 	enqueue     string
 	tryDequeue  string
 	len         string

--- a/scripts/gcp_mysql_ackqueue.sql
+++ b/scripts/gcp_mysql_ackqueue.sql
@@ -1,0 +1,122 @@
+-- AcknowelageableQueue implementation for Google Cloud MySql
+--
+-- One important issue is the absence of delete ... returning statement
+--
+-- 2025-11-17
+create table gopq_ackqueue (
+    id integer not null auto_increment primary key,
+    item blob(1024) not null,
+    enqueued_at timestamp default current_timestamp,
+    processed_at timestamp,
+    ack_deadline int,
+    retry_count int default 0
+);
+
+-- Inserts the item into the table.
+create procedure gopq_push_ack(it blob(1024))
+begin
+    insert into gopq_ackqueue (item) value (it) on duplicate key update item = it;
+end;
+
+-- Dequeue element from the queue. Until `deadline˙ passes this element will not
+-- be considered for dequeueing.
+create procedure gopq_pop_ack(now int, deadline int)
+begin
+    select id, item
+    into @id, @item
+    from gopq_ackqueue
+    where 
+            (coalesce(ack_deadline, 0) < now)
+        and processed_at is null
+    order by enqueued_at asc
+    limit 1;
+
+    if found_rows() = 1 then
+        update gopq_ackqueue
+        set ack_deadline = deadline 
+        where id = @id;
+
+        select @id as id, @item as item
+        where @id is not null;
+    end if;
+end;
+
+-- Ack processing of the element. Record is removed from the table.
+create procedure gopq_ack_delete(id int, now int)
+begin
+    delete from gopq_ackqueue
+    where
+            gopq_ackqueue.id = id
+        and ack_deadline >= now;
+end;
+
+-- Ack processing of the element. Record is marked as processed.
+create procedure gopq_ack_store(id int, now int)
+begin
+    update gopq_ackqueue
+    set processed_at = current_timestamp
+    where
+            gopq_ackqueue.id = id
+        and ack_deadline >= now;
+end;
+
+-- Return the number of elements in the queue. If the deadline is in the future
+-- then the record doesn't count.
+create procedure gopq_len_ack(now int)
+begin
+    select count(1) from gopq_ackqueue
+    where 
+            (coalesce(ack_deadline, 0) < now)
+        and processed_at is null;
+end;
+
+-- Return the internal processing details of the record.
+create procedure gopq_selectItemDetails(id int)
+begin
+    select
+        retry_count
+        , ack_deadline
+    from
+        gopq_ackqueue
+    where
+        gopq_ackqueue.id = id;
+end
+
+-- Remove the record from the table. Used on recorde that failed to ack more
+-- than allowed number of times.
+create procedure gopq_deleteItem(id int)
+begin
+  select item
+    into @item
+    from gopq_ackqueue
+    where 
+        gopq_ackqueue.id = id;
+
+    delete from gopq_ackqueue
+    where gopq_ackqueue.id = @id;
+
+    select @item as item;
+end
+
+-- Moves the record's deadline (into the future, deadline > now), thus putting
+-- it back to the queue.
+create procedure gopq_updateForRetry(deadline int, id int)
+begin
+    update gopq_ackqueue
+    set 
+        deadline = deadline
+        , retry_count = retry_count + 1
+    where 
+        gopq_ackqueue.id = id;
+end
+
+-- Moves the record's deadline (into the future, deadline > now) but keeps the
+-- retry counter.
+create procedure gopq_expireAckDeadline(deadline int, id int)
+begin
+    update gopq_ackqueue
+    set 
+        gopq_ackqueue.deadline = deadline
+    where 
+        gopq_ackqueue.id = id;
+end

--- a/scripts/gcp_mysql_simple_queue.sql
+++ b/scripts/gcp_mysql_simple_queue.sql
@@ -2,7 +2,7 @@
 --
 -- One important issue is the absence of delete ... returning statement
 --
--- 2025-11-14
+-- 2025-11-17
 create table gopq_queue (
     id integer not null auto_increment primary key,
     item blob(1024) not null,
@@ -10,6 +10,7 @@ create table gopq_queue (
     processed_at timestamp
 );
 
+-- Inserts the item into the table.
 create procedure gopq_push(it blob(1024))
 begin
     insert into gopq_queue (item) value (it);
@@ -27,6 +28,7 @@ begin
     order by enqueued_at asc
     limit 1;
 
+
     update gopq_queue
     set processed_at = current_timestamp
     where id = @id;
@@ -34,8 +36,7 @@ begin
     select @id as id, @item as item;
 end;
 
--- Dequeue element from the queue and deletes the record. Helps keeping database
--- small and thus lowers the maintenance costs.
+-- Dequeue element from the queue and deletes the record from the table. 
 create procedure gopq_pop_delete()
 begin
     select id, item
@@ -52,8 +53,10 @@ begin
     select @id as id, @item as item;
 end;
 
+-- Return the number of elements in the queue.
 create procedure gopq_len()
 begin
-    select count(1) from gopq_queue
+    select count(1) 
+    from gopq_queue
     where processed_at is null;
 end;

--- a/scripts/gcp_mysql_simple_queue.sql
+++ b/scripts/gcp_mysql_simple_queue.sql
@@ -28,12 +28,13 @@ begin
     order by enqueued_at asc
     limit 1;
 
+    if found_rows() = 1 then
+        update gopq_queue
+        set processed_at = current_timestamp
+        where id = @id;
 
-    update gopq_queue
-    set processed_at = current_timestamp
-    where id = @id;
-
-    select @id as id, @item as item;
+        select @id as id, @item as item;
+    end if;
 end;
 
 -- Dequeue element from the queue and deletes the record from the table. 
@@ -47,10 +48,12 @@ begin
     order by enqueued_at asc
     limit 1;
 
-    delete from gopq_queue
-    where id = @id;
+    if found_rows() = 1 then
+        delete from gopq_queue
+        where id = @id;
 
-    select @id as id, @item as item;
+        select @id as id, @item as item;
+    end if;
 end;
 
 -- Return the number of elements in the queue.

--- a/scripts/gcp_mysql_simple_queue.sql
+++ b/scripts/gcp_mysql_simple_queue.sql
@@ -1,0 +1,59 @@
+-- Queue implementation for Google Cloud MySql
+--
+-- One important issue is the absence of delete ... returning statement
+--
+-- 2025-11-14
+create table gopq_queue (
+    id integer not null auto_increment primary key,
+    item blob(1024) not null,
+    enqueued_at timestamp default current_timestamp,
+    processed_at timestamp
+);
+
+create procedure gopq_push(it blob(1024))
+begin
+    insert into gopq_queue (item) value (it);
+end;
+
+-- Dequeue element from the queue. Element is left in the table but no longer
+-- considered for any queue operation.
+create procedure gopq_pop_store()
+begin
+    select id, item
+    into @id, @item
+    from gopq_queue
+    where 
+        processed_at is null
+    order by enqueued_at asc
+    limit 1;
+
+    update gopq_queue
+    set processed_at = current_timestamp
+    where id = @id;
+
+    select @id as id, @item as item;
+end;
+
+-- Dequeue element from the queue and deletes the record. Helps keeping database
+-- small and thus lowers the maintenance costs.
+create procedure gopq_pop_delete()
+begin
+    select id, item
+    into @id, @item
+    from gopq_queue
+    where 
+        processed_at is null
+    order by enqueued_at asc
+    limit 1;
+
+    delete from gopq_queue
+    where id = @id;
+
+    select @id as id, @item as item;
+end;
+
+create procedure gopq_len()
+begin
+    select count(1) from gopq_queue
+    where processed_at is null;
+end;

--- a/scripts/gcp_mysql_unique_ackqueue.sql
+++ b/scripts/gcp_mysql_unique_ackqueue.sql
@@ -1,0 +1,128 @@
+-- AcknowelageableQueue implementation for Google Cloud MySql
+--
+-- One important issue is the absence of delete ... returning statement
+--
+-- 2025-11-17
+-- This queue allows for itemm to reappear in the queue once it has been 
+-- processed - the only limitation is that there ie at most 1 element of its
+-- kind active in the queue.
+create table gopq_ackqueue (
+    id integer not null auto_increment primary key,
+    item blob(1024) not null,
+    itemmd5 binary(16) as (unhex(md5(item))) stored,
+    itemsha varchar(64) as (sha2(item, 256)) stored,
+    enqueued_at timestamp default current_timestamp,
+    processed_at timestamp,
+    ack_deadline int,
+    retry_count int default 0,
+    unique key gopq_unique (itemmd5, itemsha, processed)
+);
+
+-- Inserts the item into the table.
+create procedure gopq_push_ack(it blob(1024))
+begin
+    insert into gopq_ackqueue (item) value (it) on duplicate key update item = it;
+end;
+
+-- Dequeue element from the queue. Until `deadline˙ passes this element will not
+-- be considered for dequeueing.
+create procedure gopq_pop_ack(now int, deadline int)
+begin
+    select id, item
+    into @id, @item
+    from gopq_ackqueue
+    where 
+            (coalesce(ack_deadline, 0) < now)
+        and processed_at is null
+    order by enqueued_at asc
+    limit 1;
+
+    if found_rows() = 1 then
+        update gopq_ackqueue
+        set ack_deadline = deadline 
+        where id = @id;
+
+        select @id as id, @item as item
+        where @id is not null;
+    end if;
+end;
+
+-- Ack processing of the element. Record is removed from the table.
+create procedure gopq_ack_delete(id int, now int)
+begin
+    delete from gopq_ackqueue
+    where
+            gopq_ackqueue.id = id
+        and ack_deadline >= now;
+end;
+
+-- Ack processing of the element. Record is marked as processed.
+create procedure gopq_ack_store(id int, now int)
+begin
+    update gopq_ackqueue
+    set processed_at = current_timestamp
+    where
+            gopq_ackqueue.id = id
+        and ack_deadline >= now;
+end;
+
+-- Return the number of elements in the queue. If the deadline is in the future
+-- then the record doesn't count.
+create procedure gopq_len_ack(now int)
+begin
+    select count(1) from gopq_ackqueue
+    where 
+            (coalesce(ack_deadline, 0) < now)
+        and processed_at is null;
+end;
+
+-- Return the internal processing details of the record.
+create procedure gopq_selectItemDetails(id int)
+begin
+    select
+        retry_count
+        , ack_deadline
+    from
+        gopq_ackqueue
+    where
+        gopq_ackqueue.id = id;
+end
+
+-- Remove the record from the table. Used on recorde that failed to ack more
+-- than allowed number of times.
+create procedure gopq_deleteItem(id int)
+begin
+  select item
+    into @item
+    from gopq_ackqueue
+    where 
+        gopq_ackqueue.id = id;
+
+    delete from gopq_ackqueue
+    where gopq_ackqueue.id = @id;
+
+    select @item as item;
+end
+
+-- Moves the record's deadline (into the future, deadline > now), thus putting
+-- it back to the queue.
+create procedure gopq_updateForRetry(deadline int, id int)
+begin
+    update gopq_ackqueue
+    set 
+        deadline = deadline
+        , retry_count = retry_count + 1
+    where 
+        gopq_ackqueue.id = id;
+end
+
+-- Moves the record's deadline (into the future, deadline > now) but keeps the
+-- retry counter.
+create procedure gopq_expireAckDeadline(deadline int, id int)
+begin
+    update gopq_ackqueue
+    set 
+        gopq_ackqueue.deadline = deadline
+    where 
+        gopq_ackqueue.id = id;
+end

--- a/scripts/gcp_mysql_unique_queue.sql
+++ b/scripts/gcp_mysql_unique_queue.sql
@@ -1,0 +1,63 @@
+-- Unique queue implementation for Google Cloud MySql
+--
+-- One important issue is the absence of delete ... returning statement
+--
+-- 2025-11-14
+create table gopq_queue (
+    id integer not null auto_increment primary key,
+    item blob(1024) not null,
+    itemmd5 binary(16) as (unhex(md5(item))) stored,
+    itemsha varchar(64) as (sha2(item, 256)) stored,
+    enqueued_at timestamp default current_timestamp,
+    processed_at timestamp,
+    unique(itemmd5),
+    unique(itemsha)
+);
+
+create procedure gopq_push(it blob(1024))
+begin
+    insert into gopq_queue (item) value (it) on duplicate key update item = it;
+end;
+
+-- Dequeue element from the queue. Element is left in the table but no longer
+-- considered for any queue operation.
+create procedure gopq_pop_store()
+begin
+    select id, item
+    into @id, @item
+    from gopq_queue
+    where 
+        processed_at is null
+    order by enqueued_at asc
+    limit 1;
+
+    update gopq_queue
+    set processed_at = current_timestamp
+    where id = @id;
+
+    select @id as id, @item as item;
+end;
+
+-- Dequeue element from the queue and deletes the record. Helps keeping database
+-- small and thus lowers the maintenance costs.
+create procedure gopq_pop_delete()
+begin
+    select id, item
+    into @id, @item
+    from gopq_queue
+    where 
+        processed_at is null
+    order by enqueued_at asc
+    limit 1;
+
+    delete from gopq_queue
+    where id = @id;
+
+    select @id as id, @item as item;
+end;
+
+create procedure gopq_len()
+begin
+    select count(1) from gopq_queue
+    where processed_at is null;
+end;

--- a/scripts/gcp_mysql_unique_queue.sql
+++ b/scripts/gcp_mysql_unique_queue.sql
@@ -31,11 +31,13 @@ begin
     order by enqueued_at asc
     limit 1;
 
-    update gopq_queue
-    set processed_at = current_timestamp
-    where id = @id;
+    if found_rows() = 1 then
+        update gopq_queue
+        set processed_at = current_timestamp
+        where id = @id;
 
-    select @id as id, @item as item;
+        select @id as id, @item as item;
+    end if;
 end;
 
 -- Dequeue element from the queue and deletes the record. Helps keeping database
@@ -50,10 +52,12 @@ begin
     order by enqueued_at asc
     limit 1;
 
-    delete from gopq_queue
-    where id = @id;
+    if found_rows() = 1 then
+        delete from gopq_queue
+        where id = @id;
 
-    select @id as id, @item as item;
+        select @id as id, @item as item;
+    end if;
 end;
 
 create procedure gopq_len()

--- a/simple_queue.go
+++ b/simple_queue.go
@@ -63,7 +63,6 @@ func NewSimpleQueue(filePath string) (*Queue, error) {
 		pollInterval: defaultPollInterval,
 		notifyChan:   internal.MakeNotifyChan(),
 		queries: baseQueries{
-			createTable: formattedCreateTableQuery,
 			enqueue:     formattedEnqueueQuery,
 			tryDequeue:  formattedTryDequeueQuery,
 			len:         formattedLenQuery,

--- a/simple_queue.go
+++ b/simple_queue.go
@@ -59,7 +59,6 @@ func NewSimpleQueue(filePath string) (*Queue, error) {
 
 	return &Queue{
 		db:           db,
-		name:         tableName,
 		pollInterval: defaultPollInterval,
 		notifyChan:   internal.MakeNotifyChan(),
 		queries: baseQueries{

--- a/unique_ack_queue.go
+++ b/unique_ack_queue.go
@@ -64,7 +64,6 @@ func NewUniqueAckQueue(filePath string, opts AckOpts) (*AcknowledgeableQueue, er
 	return &AcknowledgeableQueue{
 		Queue: Queue{
 			db:           db,
-			name:         tableName,
 			pollInterval: defaultPollInterval,
 			notifyChan:   internal.MakeNotifyChan(),
 			queries: baseQueries{

--- a/unique_ack_queue.go
+++ b/unique_ack_queue.go
@@ -68,7 +68,6 @@ func NewUniqueAckQueue(filePath string, opts AckOpts) (*AcknowledgeableQueue, er
 			pollInterval: defaultPollInterval,
 			notifyChan:   internal.MakeNotifyChan(),
 			queries: baseQueries{
-				createTable: formattedCreateTableQuery,
 				enqueue:     formattedEnqueueQuery,
 				tryDequeue:  formattedTryDequeueQuery,
 				len:         formattedLenQuery,

--- a/unique_ack_queue.go
+++ b/unique_ack_queue.go
@@ -68,14 +68,20 @@ func NewUniqueAckQueue(filePath string, opts AckOpts) (*AcknowledgeableQueue, er
 			pollInterval: defaultPollInterval,
 			notifyChan:   internal.MakeNotifyChan(),
 			queries: baseQueries{
-				enqueue:     formattedEnqueueQuery,
-				tryDequeue:  formattedTryDequeueQuery,
-				len:         formattedLenQuery,
+				enqueue:    formattedEnqueueQuery,
+				tryDequeue: formattedTryDequeueQuery,
+				len:        formattedLenQuery,
 			},
 		},
 		AckOpts: opts,
 		ackQueries: ackQueries{
 			ack: formattedAckQuery,
+			ackUtilsQueries: ackUtilsQueries{
+				details:  fmt.Sprintf(sqlite.details, tableName),
+				delete:   fmt.Sprintf(sqlite.delete, tableName),
+				forRetry: fmt.Sprintf(sqlite.forRetry, tableName),
+				expire:   fmt.Sprintf(sqlite.expire, tableName),
+			},
 		},
 	}, nil
 }

--- a/unique_queue.go
+++ b/unique_queue.go
@@ -55,7 +55,6 @@ func NewUniqueQueue(filePath string) (*Queue, error) {
 
 	return &Queue{
 		db:           db,
-		name:         tableName,
 		pollInterval: defaultPollInterval,
 		notifyChan:   internal.MakeNotifyChan(),
 		queries: baseQueries{

--- a/unique_queue.go
+++ b/unique_queue.go
@@ -59,10 +59,9 @@ func NewUniqueQueue(filePath string) (*Queue, error) {
 		pollInterval: defaultPollInterval,
 		notifyChan:   internal.MakeNotifyChan(),
 		queries: baseQueries{
-			createTable: formattedCreateTableQuery,
-			enqueue:     formattedEnqueueQuery,
-			tryDequeue:  formattedTryDequeueQuery,
-			len:         formattedLenQuery,
+			enqueue:    formattedEnqueueQuery,
+			tryDequeue: formattedTryDequeueQuery,
+			len:        formattedLenQuery,
 		},
 	}, nil
 


### PR DESCRIPTION
# External database support

This PR allows for user to bring its own database (like MySQL, Postgres, MS SQL, Oracle...) to host a queue or several of them simultaneously.

Supported are normal queues of the type `Queue` and acknowledgeable queues of the type `AcknowledgeableQueue`. Particular behaviour of the queue (unique etc) then depends on the implementation of stored procedures.

Example implementations are provided for GCP dialect of MySql for simple, simple ack and unique ack queues.


